### PR TITLE
Use  for current language source, following behaviour of CRM_Core_I18n.

### DIFF
--- a/CRM/Core/Payment/Cmcic.php
+++ b/CRM/Core/Payment/Cmcic.php
@@ -246,10 +246,11 @@ class CRM_Core_Payment_Cmcic extends CRM_Core_Payment{
    * @return string
    */
   function getLanguage() {
-    $lang = explode('_', CRM_Core_Config::singleton()->lcMessages);
+    global $tsLocale;
+    $lang = substr($tsLocale, 0, 2);
     $validLangs = array('fr', 'en', 'de', 'it', 'es', 'nl', 'pt', 'sv');
-    if(in_array($lang[0], $validLangs)) {
-      return strtoupper($lang[0]);
+    if(in_array($lang, $validLangs)) {
+      return strtoupper($lang);
     }
     return 'FR';
   }


### PR DESCRIPTION
See https://redmine.fuzion.co.nz/issues/9489
