### PR TITLE
Fix IPN handling on recent civi, remove civicrm_notification_log, add README

### DIFF
--- a/CRM/Core/Payment/Cmcic.php
+++ b/CRM/Core/Payment/Cmcic.php
@@ -89,7 +89,7 @@ class CRM_Core_Payment_Cmcic extends CRM_Core_Payment{
    * @access public
    *
    */
-  function doTransferCheckout(&$params, $component) {
+  function doTransferCheckout(&$params, $component = 'contribute') {
     $component = strtolower($component);
     if ($component == 'event') {
       $baseURL = 'civicrm/event/register';
@@ -272,25 +272,10 @@ class CRM_Core_Payment_Cmcic extends CRM_Core_Payment{
     return $this->_algorithm;
   }
 
-  function handlePaymentNotification(){
-    $logTableExists = FALSE;
-    $checkTable = "SHOW TABLES LIKE 'civicrm_notification_log'";
-    $dao = CRM_Core_DAO::executeQuery($checkTable);
-    if(!$dao->N) {
-      CRM_Core_DAO::executeQuery("CREATE TABLE IF NOT EXISTS `civicrm_notification_log` (
-      `id` INT(10) NOT NULL AUTO_INCREMENT,
-      `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      `message_type` VARCHAR(255) NULL DEFAULT NULL,
-      `message_raw` LONGTEXT NULL,
-       PRIMARY KEY (`id`)
-      )");
-    }
-
-    $dao = CRM_Core_DAO::executeQuery("INSERT INTO civicrm_notification_log (message_raw, message_type) VALUES (%1, 'cmcic')",
-      array(1 => array(json_encode($_REQUEST), 'String'))
-    );
+  function handlePaymentNotification() {
     $ipn = new CRM_Core_Payment_CmcicIPN(array_merge($_REQUEST, array('exit_mode' => TRUE)));
-    $ipn->main();
+    $ipn->main($this->_paymentProcessor);
+
     //if for any reason we come back here
     CRM_Core_Error::debug_log_message( "It should not be possible to reach this line" );
   }

--- a/CRM/Core/Payment/CmcicIPN.php
+++ b/CRM/Core/Payment/CmcicIPN.php
@@ -129,8 +129,7 @@ class CRM_Core_Payment_CmcicIPN extends CRM_Core_Payment_BaseIPN{
    * @todo the references to POST throughout this class need to be removed
    * @return void|boolean|Ambigous <void, boolean>
    */
-  function main() {
-    $paymentProcessor = civicrm_api3('payment_processor', 'getsingle', array('id' => $this->retrieve('processor_id', 'Integer', TRUE)));
+  function main($paymentProcessor) {
     //we say contribute here as a dummy param as we are using the api to complete & we don't need to know
     $this->_paymentProcessor = new CRM_Core_Payment_Cmcic('contribute', $paymentProcessor);
     if(!$this->cmcic_validate_response()) {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Credit Mutuel (Monetico) CiviCRM integration
+
+Extension to process payments using the Monetico payment processor by Credit Mutuel.
+
+Distributed under the terms of the GNU Affero General public license (AGPL 3). See LICENSE.txt for details.
+
+## Requirements
+
+Tested on CiviCRM 5.35 and later.
+
+## Configuration
+
+First get the TPE key from the Monetico portal:
+
+* Login to the Monetico portal to get a "TPE security key" (https://www.monetico-services.com/en/identification/authentification.html)
+* Click on the Parameters menu
+  * Go through the process to validate and email. It will send a code to one of the configured emails.
+  * The TPE key will be displayed on screen. It's an alphanumeric code of 40 characters.
+  * Also download the security key (something.key). It includes the same 40 char key, as well as the HMAC-SHA1 key.
+
+Then in CiviCRM, configure the Payment Processor:
+
+* Enable this extension (Administer > System Settings > Extensions)
+* Add the CMCIC/Monetico payment processor (Administer > System Settings > Payment Processors)
+  * POS terminal number: 6 digit code of the TPE
+  * Merchant security key: the sha1 key
+  * Site code: short alphanumeric name related to the organization. Ex: "acmeorg".
+  * Algorithm: sha1
+  * Site URL: https://p.monetico-services.com/paiement.cgi
+  * Site URL for tests: https://p.monetico-services.com/test/paiement.cgi
+
+Note that the TPE key/sha1/site code are the same for the dev and production configurations. Only the URL is different.
+
+## Return URL (or webhook)
+
+The Monetico merchant support must be contacted to set the return URL.
+
+## Testing
+
+Most often while testing Monetico will show an error that the TPE is closed. It has to be re-opened every 15 days.
+
+* Login to the Monetico portal
+* Go to the dev environment
+* Click "TPE status", edit, and re-open for 15 days.
+
+For test cards:  
+https://p.monetico-services.com/test/cartes_test.cgi?lgue=FR
+
+## Going to production
+
+It might be necessary to contact Monetico support to enable production mode.


### PR DESCRIPTION
We were having issues with getting the IPN to be processed using CiviCRM 5.40, because the IPN class could not find the `processor_id`.

I realize this extension is probably abandoned. I don't mind leaving it on a fork, or we can move it to Gitlab?