### PR TITLE
Update cmcic.civix.php

### DIFF
--- a/cmcic.civix.php
+++ b/cmcic.civix.php
@@ -130,7 +130,7 @@ function _cmcic_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         } elseif (is_dir($path)) {
           $todos[] = $path;
         }


### PR DESCRIPTION
Fix PHP8.1 error:
Error: Array and string offset access syntax with curly braces is no longer supported in /home/parisaqu/www/sites/default/files/civicrm/ext/nz.co.fuzion.cmcic-master/cmcic.civix.php, line 133