### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/templates/CRM/Cmcic/Page/Cmcic.tpl
+++ b/templates/CRM/Cmcic/Page/Cmcic.tpl
@@ -4,7 +4,7 @@ target="_top" action="{$url}">
 {foreach from=$fields key=k item=field}
   <input type="hidden" name="{$k}" value="{$field}">
 {/foreach}
-<input type="submit" name="bouton" value="{ts}Pay Now{/ts}">
+<input type="submit" name="bouton" value="{ts escape='htmlattribute'}Pay Now{/ts}">
 </form>
 <script type="text/javascript">
 document.getElementById("form").submit();


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.